### PR TITLE
Simplified code to handle datatype attribute pipe separator

### DIFF
--- a/openehr-ms/test_unflatten.js
+++ b/openehr-ms/test_unflatten.js
@@ -156,6 +156,40 @@ var flatJson = {
     "nss_respect_form/composer|name": "Dr Jonty Shannon"
 };
 
+var flatjson2 = {
+  "ctx/composer_name": "Dr Jonty Shannon",
+  "ctx/health_care_facility|id": "999999-345",
+  "ctx/health_care_facility|name": "Home",
+  "ctx/id_namespace": "NHS-UK",
+  "ctx/id_scheme": "2.16.840.1.113883.2.1.4.3",
+  "ctx/language": "en",
+  "ctx/territory": "GB",
+  "ctx/time": "2016-12-20T00:11:02.518+02:00",
+  "adverse_reaction_list/allergies_and_adverse_reactions/adverse_reaction_risk:0/_uid": "{{$guid}}",
+  "adverse_reaction_list/allergies_and_adverse_reactions/adverse_reaction_risk:0/causative_agent|code": "304270095",
+  "adverse_reaction_list/allergies_and_adverse_reactions/adverse_reaction_risk:0/causative_agent|value": "Erythromycin",
+  "adverse_reaction_list/allergies_and_adverse_reactions/adverse_reaction_risk:0/causative_agent|terminology": "SNOMED-CT",
+
+  "adverse_reaction_list/allergies_and_adverse_reactions/adverse_reaction_risk:0/reaction_details/manifestation:0": "Itch",
+  "adverse_reaction_list/allergies_and_adverse_reactions/adverse_reaction_risk:0/reaction_details/manifestation:1": "Sneezles",
+
+  "adverse_reaction_list/allergies_and_adverse_reactions/adverse_reaction_risk:0/category|code": "at0122",
+ "adverse_reaction_list/allergies_and_adverse_reactions/adverse_reaction_risk:0/reaction_details/manifestation:2|code": "422400008",
+  "adverse_reaction_list/allergies_and_adverse_reactions/adverse_reaction_risk:0/reaction_details/manifestation:2|value": "Vomiting",
+  "adverse_reaction_list/allergies_and_adverse_reactions/adverse_reaction_risk:0/reaction_details/manifestation:2|terminology": "SNOMED-CT",
+  "adverse_reaction_list/allergies_and_adverse_reactions/adverse_reaction_risk:0/reaction_details/manifestation:3|code": "422400008",
+  "adverse_reaction_list/allergies_and_adverse_reactions/adverse_reaction_risk:0/reaction_details/manifestation:3|value": "Diarrhoea",
+  "adverse_reaction_list/allergies_and_adverse_reactions/adverse_reaction_risk:0/reaction_details/manifestation:3|terminology": "SNOMED-CT",
+
+  "adverse_reaction_list/allergies_and_adverse_reactions/adverse_reaction_risk:0/reaction_details/comment": "Reported by patient's carer",
+  "adverse_reaction_list/allergies_and_adverse_reactions/adverse_reaction_risk:0/last_updated": "2017-12-20T00:11:02.518+02:00"
+};
+
+
 var json = unflatten(flatJson);
+
+console.log(JSON.stringify(json, null, 2));
+
+var json = unflatten(flatJson2);
 
 console.log(JSON.stringify(json, null, 2));

--- a/openehr-ms/utils/unflatten.js
+++ b/openehr-ms/utils/unflatten.js
@@ -44,8 +44,9 @@ module.exports = function(flatJson) {
     value = flatJson[path];
 
     // pre-process to sort out | anomalies
+    path = path.replace('|','/|');
 
-    if (path.indexOf('|') !== -1) {
+   /*  if (path.indexOf('|') !== -1) {
       var pieces = path.split('|');
       var prev;
       var lc;
@@ -68,7 +69,7 @@ module.exports = function(flatJson) {
         path = pieces.join('|');
       }
     }
-
+ */
     // now begin processing
 
     pieces = path.split('/');

--- a/openehr-ms/utils/unflatten.js
+++ b/openehr-ms/utils/unflatten.js
@@ -100,9 +100,26 @@ module.exports = function(flatJson) {
             ref[name][index] = {};
           }
         }
-        if (typeof ref[name][index] === 'undefined') {
-          ref[name][index] = {};
-        }
+        else {
+          if (typeof ref[name] === 'undefined') {
+              ref[name] = [];
+              if (ix === lastIndex) {
+                  ref[name][index] = value;
+              }
+              else {
+                  ref[name][index] = {};
+              }
+          }
+          if (typeof ref[name][index] === 'undefined') {
+            // ref[name][index] = {};
+             if (ix === lastIndex) {
+                 ref[name][index] = value;
+             }
+             else {
+                 ref[name][index] = {};
+             }
+          }
+         }
         ref = ref[name][index];
       }
     });


### PR DESCRIPTION
The use of the pipe separator is actually morte predictable than the original cpode suggests. It only ever occurs in leaf nodes and signifies that the datapoints are attributes within a datatype. I think you can dop a simple search/replace to prefix a / character.  